### PR TITLE
Bug fix and some code clean up

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -5,7 +5,9 @@
 USE_OPT_SCHED YES
 
 # These 3 flags control which schedulers will be used.
-# Each one can be individually toggled.
+# Each one can be individually toggled. The heuristic
+# list scheduler or ACO must be run before the 
+# enumerator.
 # VALUES:
 # YES
 # NO
@@ -13,8 +15,19 @@ USE_OPT_SCHED YES
 HEUR_ENABLED YES
 # ACO_ENABLED is the Ant Colony Optimization scheduler.
 ACO_ENABLED YES
-# BB_ENABLED is the Branch and Bound scheduler.
-BB_ENABLED YES
+# ENUM_ENABLED is the Branch and Bound scheduler.
+ENUM_ENABLED YES
+
+# Controls when ACO should be run, either before or
+# after the enumerator. Both can be enabled at the
+# same time. ACO is disabled if both are disabled.
+# Run ACO before the enumerator
+# VALUES:
+# YES
+# NO
+ACO_BEFORE_ENUM YES
+# Run ACO after the enumerator
+ACO_AFTER_ENUM NO
 
 # Print spill counts
 # Same options as use optimal scheduling.

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -77,7 +77,7 @@ SPILL_COST_FUNCTION PERP
 # making spill cost minimization the primary objective) and smaller on
 # architectures with in-order execution like SPARC (thus making scheduling
 # the primary objective).
-SPILL_COST_WEIGHT 100000
+SPILL_COST_WEIGHT 10000
 
 # Precision of latency info:
 # PRECISE: use precise latencies from the machine_model.cfg file

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -57,7 +57,7 @@ private:
   int ants_per_iteration;
   bool print_aco_trace;
   std::vector<double> scores(std::vector<Choice> ready, SchedInstruction *last);
-  InstSchedule* InitialSchedule_;
+  InstSchedule* InitialSchedule;
   bool VrfySched_;
 };
 

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -31,7 +31,7 @@ public:
   inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
   // Set the initial schedule for ACO 
   // Default is NULL if none are set.
-  void SetInitialSched(InstSchedule *sched);
+  void setInitialSched(InstSchedule *Sched);
   
 private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);
@@ -57,8 +57,8 @@ private:
   int ants_per_iteration;
   bool print_aco_trace;
   std::vector<double> scores(std::vector<Choice> ready, SchedInstruction *last);
-  InstSchedule* initialSchedule_;
-  bool vrfySched_;
+  InstSchedule* InitialSchedule_;
+  bool VrfySched_;
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -31,7 +31,7 @@ public:
   inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
   // Set the initial schedule for ACO 
   // Default is NULL if none are set.
-  void setInitialSched(InstSchedule *sched);
+  void SetInitialSched(InstSchedule *sched);
   
 private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -1,4 +1,10 @@
-// Ant colony optimizing scheduler
+/*******************************************************************************
+Description:  Implements an Ant colony optimizing scheduler
+Author:       Theodore Dubois
+Created:      Nov. 2017
+Updated By:   Ciprian Elies and Vang Thao
+Last Update:  Jan. 2020
+*******************************************************************************/
 
 #ifndef OPTSCHED_ACO_H
 #define OPTSCHED_ACO_H
@@ -19,11 +25,14 @@ class ACOScheduler : public ConstrainedScheduler {
 public:
   ACOScheduler(DataDepGraph *dataDepGraph, MachineModel *machineModel,
                InstCount upperBound, SchedPriorities priorities,
-               InstSchedule* initialSchedule, bool vrfySched);
+               bool vrfySched);
   virtual ~ACOScheduler();
   FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region);
   inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
-
+  // Set the initial schedule for ACO 
+  // Default is NULL if none are set.
+  void setInitialSched(InstSchedule *sched);
+  
 private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);
   pheremone_t &Pheremone(InstCount from, InstCount to);
@@ -49,6 +58,7 @@ private:
   bool print_aco_trace;
   std::vector<double> scores(std::vector<Choice> ready, SchedInstruction *last);
   InstSchedule* initialSchedule_;
+  bool vrfySched_;
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -3,7 +3,8 @@ Description:  Implements an abstract base class for representing scheduling
               regions.
 Author:       Ghassan Shobaki
 Created:      Apr. 2005
-Last Update:  Apr. 2011
+Updated By:   Ciprian Elies and Vang Thao
+Last Update:  Jan. 2020
 *******************************************************************************/
 
 #ifndef OPTSCHED_SCHED_REGION_SCHED_REGION_H
@@ -130,8 +131,6 @@ protected:
   InstCount hurstcSchedLngth_;
   InstCount acoScheduleLength_; //TODO: CHIPPIE: Is this really needed? Confirm please!
   InstCount acoScheduleCost_; //TODO: CHIPPIE: Is this really needed? Confirm please!
-  InstCount initialScheduleCost_;
-  InstCount initialScheduleLength_;
 
   // The schedule currently used by the enumerator
   InstSchedule *enumCrntSched_;
@@ -186,7 +185,7 @@ protected:
   // TODO(max): Document.
   void CmputLwrBounds_(bool useFileBounds);
   // TODO(max): Document.
-  bool CmputUprBounds_(InstSchedule *schedule, bool useFileBounds, InstCount& scheduleCost, InstCount scheduleLength);
+  bool CmputUprBounds_(InstSchedule *schedule, bool useFileBounds);
   // Handle the enumerator's result
   void HandlEnumrtrRslt_(FUNC_RESULT rslt, InstCount trgtLngth);
 
@@ -226,6 +225,11 @@ protected:
 
   // (Chris) Get the SLIL for each set
   virtual const std::vector<int> &GetSLIL_() const = 0;
+  
+  FUNC_RESULT runACO(InstSchedule *returnSched, InstSchedule *initSched);
+  // Compare first and second schedule and put the best in third.
+  void compareSchedules(InstSchedule *first, InstSchedule *second, InstSchedule *&third);
+  
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -129,8 +129,8 @@ protected:
   // The nomal heuristic scheduling results.
   InstCount hurstcCost_;
   InstCount hurstcSchedLngth_;
-  InstCount acoScheduleLength_;
-  InstCount acoScheduleCost_;
+  InstCount AcoScheduleLength_;
+  InstCount AcoScheduleCost_;
 
   // The schedule currently used by the enumerator
   InstSchedule *enumCrntSched_;
@@ -225,11 +225,11 @@ protected:
 
   // (Chris) Get the SLIL for each set
   virtual const std::vector<int> &GetSLIL_() const = 0;
-  
-  FUNC_RESULT runACO(InstSchedule *returnSched, InstSchedule *initSched);
+
+  FUNC_RESULT runACO(InstSchedule *ReturnSched, InstSchedule *InitSched);
   // Compare first and second schedule and put the best in third.
-  void compareSchedules(InstSchedule *first, InstSchedule *second, InstSchedule *&third);
-  
+  void compareSchedules(InstSchedule *First, InstSchedule *Second,
+                        InstSchedule *&Third);
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -127,10 +127,10 @@ protected:
   InstCount bestCost_;
   InstCount bestSchedLngth_;
   // The nomal heuristic scheduling results.
-  InstCount hurstcCost_; //TODO: CHIPPIE: This should ONLY be used for the heuristic stuff. NOT for initial schedule stuff...
+  InstCount hurstcCost_;
   InstCount hurstcSchedLngth_;
-  InstCount acoScheduleLength_; //TODO: CHIPPIE: Is this really needed? Confirm please!
-  InstCount acoScheduleCost_; //TODO: CHIPPIE: Is this really needed? Confirm please!
+  InstCount acoScheduleLength_;
+  InstCount acoScheduleCost_;
 
   // The schedule currently used by the enumerator
   InstSchedule *enumCrntSched_;

--- a/include/opt-sched/Scheduler/stats.h
+++ b/include/opt-sched/Scheduler/stats.h
@@ -286,7 +286,7 @@ extern IntDistributionStat traceOptimalScheduleLength;
 
 extern IntDistributionStat regionBuildTime;
 extern IntDistributionStat heuristicTime;
-extern IntDistributionStat acoTime;
+extern IntDistributionStat AcoTime;
 extern IntDistributionStat boundComputationTime;
 extern IntDistributionStat enumerationTime;
 extern IntDistributionStat enumerationToHeuristicTimeRatio;

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -33,9 +33,9 @@ double RandDouble(double min, double max) {
 
 ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
                            MachineModel *machineModel, InstCount upperBound,
-                           SchedPriorities priorities, InstSchedule* initialSchedule,
-                           bool vrfySched)
+                           SchedPriorities priorities, bool vrfySched)
     : ConstrainedScheduler(dataDepGraph, machineModel, upperBound) {
+  vrfySched_ = vrfySched;
   prirts_ = priorities;
   rdyLst_ = new ReadyList(dataDepGraph_, priorities);
   count_ = dataDepGraph->GetInstCnt();
@@ -62,13 +62,7 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
   */
   int pheremone_size = (count_ + 1) * count_;
   pheremone_ = new pheremone_t[pheremone_size];
-
   this->initialSchedule_ = NULL;
-  if (initialSchedule)
-  {
-    this->initialSchedule_ = new InstSchedule(machineModel, dataDepGraph, vrfySched);
-    this->initialSchedule_->Copy(initialSchedule);
-  }
 }
 
 ACOScheduler::~ACOScheduler() {
@@ -436,4 +430,11 @@ void PrintSchedule(InstSchedule *schedule) {
   }
   std::cerr << std::endl;
   schedule->ResetInstIter();
+}
+
+void ACOScheduler::setInitialSched(InstSchedule *sched) {
+  if (sched) {
+    this->initialSchedule_ = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
+    this->initialSchedule_->Copy(sched);
+  }
 }

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -174,6 +174,7 @@ InstSchedule *ACOScheduler::FindOneSchedule() {
   if (maxPriority == 0)
     maxPriority = 1; // divide by 0 is bad
   Initialize_();
+  rgn_->InitForSchdulng();
 
   while (!IsSchedComplete_()) {
     // convert the ready list from a custom priority queue to a std::vector,

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -433,7 +433,7 @@ void PrintSchedule(InstSchedule *schedule) {
   schedule->ResetInstIter();
 }
 
-void ACOScheduler::SetInitialSched(InstSchedule *Sched) {
+void ACOScheduler::setInitialSched(InstSchedule *Sched) {
   if (Sched) {
     InitialSchedule = new InstSchedule(machMdl_, dataDepGraph_, VrfySched_);
     InitialSchedule->Copy(Sched);

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -35,7 +35,7 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
                            MachineModel *machineModel, InstCount upperBound,
                            SchedPriorities priorities, bool vrfySched)
     : ConstrainedScheduler(dataDepGraph, machineModel, upperBound) {
-  vrfySched_ = vrfySched;
+  VrfySched_ = vrfySched;
   prirts_ = priorities;
   rdyLst_ = new ReadyList(dataDepGraph_, priorities);
   count_ = dataDepGraph->GetInstCnt();
@@ -62,7 +62,7 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
   */
   int pheremone_size = (count_ + 1) * count_;
   pheremone_ = new pheremone_t[pheremone_size];
-  this->initialSchedule_ = NULL;
+  InitialSchedule = nullptr;
 }
 
 ACOScheduler::~ACOScheduler() {
@@ -267,7 +267,7 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
     pheremone_[i] = initialValue_;
   std::cerr << "initialValue_" << initialValue_ << std::endl;
 
-  InstSchedule *bestSchedule = initialSchedule_;
+  InstSchedule *bestSchedule = InitialSchedule;
   if (bestSchedule) {
     UpdatePheremone(bestSchedule);
   }
@@ -433,9 +433,9 @@ void PrintSchedule(InstSchedule *schedule) {
   schedule->ResetInstIter();
 }
 
-void ACOScheduler::SetInitialSched(InstSchedule *sched) {
-  if (sched) {
-    this->initialSchedule_ = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-    this->initialSchedule_->Copy(sched);
+void ACOScheduler::SetInitialSched(InstSchedule *Sched) {
+  if (Sched) {
+    InitialSchedule = new InstSchedule(machMdl_, dataDepGraph_, VrfySched_);
+    InitialSchedule->Copy(Sched);
   }
 }

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -268,7 +268,7 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
   std::cerr << "initialValue_" << initialValue_ << std::endl;
 
   InstSchedule *bestSchedule = initialSchedule_;
-  if (bestSchedule) { //TODO: CHIPPIE: Should it use a sched ini option to make ACO consider an initial schedule, or not?
+  if (bestSchedule) {
     UpdatePheremone(bestSchedule);
   }
   Config &schedIni = SchedulerOptions::getInstance();
@@ -433,7 +433,7 @@ void PrintSchedule(InstSchedule *schedule) {
   schedule->ResetInstIter();
 }
 
-void ACOScheduler::setInitialSched(InstSchedule *sched) {
+void ACOScheduler::SetInitialSched(InstSchedule *sched) {
   if (sched) {
     this->initialSchedule_ = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
     this->initialSchedule_->Copy(sched);

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -382,7 +382,7 @@ InstCount BBWithSpill::CmputCost_(InstSchedule *sched, COST_COMP_MODE compMode,
   InstCount cycleNum;
   InstCount slotNum;
   SchedInstruction *inst;
-
+/* ACO Doesn't need to re-calculate spill cost anymore.
   if (compMode == CCM_STTC) {
     if (spillCostFunc_ != SCF_SPILLS) {
       InitForCostCmputtn_();
@@ -399,7 +399,7 @@ InstCount BBWithSpill::CmputCost_(InstSchedule *sched, COST_COMP_MODE compMode,
       regAlloc.AllocRegs();
       crntSpillCost_ = regAlloc.GetCost();
     }
-  }
+  }*/
 
   assert(sched->IsComplete());
   InstCount cost = sched->GetCrntLngth() * schedCostFactor_;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -382,24 +382,25 @@ InstCount BBWithSpill::CmputCost_(InstSchedule *sched, COST_COMP_MODE compMode,
   InstCount cycleNum;
   InstCount slotNum;
   SchedInstruction *inst;
-/* ACO Doesn't need to re-calculate spill cost anymore.
+  
   if (compMode == CCM_STTC) {
-    if (spillCostFunc_ != SCF_SPILLS) {
-      InitForCostCmputtn_();
+    // ACO doesn't need to re-calculate spill cost.
+    // if (spillCostFunc_ != SCF_SPILLS) {
+    //   InitForCostCmputtn_();
 
-      for (instNum = sched->GetFrstInst(cycleNum, slotNum);
-           instNum != INVALID_VALUE;
-           instNum = sched->GetNxtInst(cycleNum, slotNum)) {
-        inst = dataDepGraph_->GetInstByIndx(instNum);
-        SchdulInst(inst, cycleNum, slotNum, trackCnflcts);
-      }
-    } else {
+    //  for (instNum = sched->GetFrstInst(cycleNum, slotNum);
+    //       instNum != INVALID_VALUE;
+    //       instNum = sched->GetNxtInst(cycleNum, slotNum)) {
+    //    inst = dataDepGraph_->GetInstByIndx(instNum);
+    //    SchdulInst(inst, cycleNum, slotNum, trackCnflcts);
+    //  }
+    if (spillCostFunc_ == SCF_SPILLS) {
       LocalRegAlloc regAlloc(sched, dataDepGraph_);
       regAlloc.SetupForRegAlloc();
       regAlloc.AllocRegs();
       crntSpillCost_ = regAlloc.GetCost();
     }
-  }*/
+  }
 
   assert(sched->IsComplete());
   InstCount cost = sched->GetCrntLngth() * schedCostFactor_;
@@ -768,7 +769,7 @@ void BBWithSpill::UnschdulInst(SchedInstruction *inst, InstCount cycleNum,
 }
 /*****************************************************************************/
 
-void BBWithSpill::FinishHurstc_() { //TODO: CHIPPIE: Should this be added for ACO as well?
+void BBWithSpill::FinishHurstc_() {
 
 #ifdef IS_DEBUG_BBSPILL_COST
   stats::traceCostLowerBound.Record(costLwrBound_);

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -800,7 +800,7 @@ void SchedRegion::InitSecondPass() { isSecondPass = true; }
 FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
                                 InstSchedule *InitSched) {
   InitForSchdulng();
-  AcoScheduler *AcoSchdulr = new AcoScheduler(
+  ACOScheduler *AcoSchdulr = new ACOScheduler(
       dataDepGraph_, machMdl_, abslutSchedUprBound_, hurstcPrirts_, vrfySched_);
   AcoSchdulr->setInitialSched(InitSched);
   FUNC_RESULT Rslt = AcoSchdulr->FindSchedule(ReturnSched, this);
@@ -811,7 +811,7 @@ FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
 void SchedRegion::compareSchedules(InstSchedule *First, InstSchedule *Second,
                                    InstSchedule *&Third) {
   InstCount FirstCost = First->GetCost();
-  InstCount SecondCost = second->GetCost();
+  InstCount SecondCost = Second->GetCost();
 
   // Instances where costs are equal, take sched. length into account
   if (FirstCost == SecondCost)

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -309,9 +309,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
                                 "CP Lower Bounds");
 #endif
 
-  if (rgnTimeout == 0)
-    isLstOptml = true;
-
   // (Chris): If the cost function is SLIL, then the list schedule is considered
   // optimal if PERP is 0.
   if (filterByPerp && !isLstOptml && spillCostFunc_ == SCF_SLIL) {
@@ -359,6 +356,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   InitialSchedule = bestSched_;
   InitialScheduleCost = bestCost_;
   InitialScheduleLength = bestSchedLngth_;
+
+  if (rgnTimeout == 0)
+    BbSchedulerEnabled = false;
 
   // Step #4: Find the optimal schedule if the heuristc and ACO was not optimal.
   if (BbSchedulerEnabled) {

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -37,12 +37,12 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   isSecondPass = false;
 
   totalSimSpills_ = INVALID_VALUE;
-  bestCost_ = 0;
-  bestSchedLngth_ = 0;
-  hurstcCost_ = 0;
-  hurstcSchedLngth_ = 0;
-  AcoScheduleCost_ = 0;
-  AcoScheduleLength_ = 0;
+  bestCost_ = INVALID_VALUE;
+  bestSchedLngth_ = INVALID_VALUE;
+  hurstcCost_ = INVALID_VALUE;
+  hurstcSchedLngth_ = INVALID_VALUE;
+  AcoScheduleCost_ = INVALID_VALUE;
+  AcoScheduleLength_ = INVALID_VALUE;
   enumCrntSched_ = NULL;
   enumBestSched_ = NULL;
   schedLwrBound_ = 0;

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -174,8 +174,11 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   else
     CmputLwrBounds_(false);
 
-  // Step #1: Find the heuristic schedule if enabled.
-  if (heuristicSchedulerEnabled) {
+  // Step #1: Find the heuristic schedule if enabled. 
+  // Note: Heuristic scheduler is required for the two-pass scheduler
+  // to use the sequential list scheduler which inserts stalls into
+  // the schedule found in the first pass.
+  if (heuristicSchedulerEnabled || isSecondPass) {
     cout << "TODO: Heuristic Scheduler is enabled.\n"; //TODO: Remove this debugging line when done.
     Milliseconds hurstcStart = Utilities::GetProcessorTime();
     lstSched = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -43,11 +43,8 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   hurstcSchedLngth_ = 0;
   acoScheduleCost_ = 0;
   acoScheduleLength_ = 0;
-  initialScheduleCost_ = 0;
-  initialScheduleLength_ = 0;
   enumCrntSched_ = NULL;
   enumBestSched_ = NULL;
-
   schedLwrBound_ = 0;
   schedUprBound_ = INVALID_VALUE;
 
@@ -77,6 +74,8 @@ void SchedRegion::CmputAbslutUprBound_() {
   abslutSchedUprBound_ = dataDepGraph_->GetAbslutSchedUprBound();
 }
 
+// FIXME: Heuristic cost and length is being returned by reference
+// which may cause an issue when heuristic is disabled.
 FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functions as private functions in the class.
     Milliseconds rgnTimeout, Milliseconds lngthTimeout, bool &isLstOptml,
     InstCount &bestCost, InstCount &bestSchedLngth, InstCount &hurstcCost,
@@ -84,15 +83,11 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
     const BLOCKS_TO_KEEP blocksToKeep) {
   ConstrainedScheduler *lstSchdulr = NULL;
   ConstrainedScheduler *acoSchdulr = NULL;
+  InstSchedule *initialSchedule = NULL;
   InstSchedule *lstSched = NULL;
   InstSchedule *acoSchedule = NULL;
-  llvm::opt_sched::InstCount ACOScheduleLength; //TODO: CHIPPIE: Initialization value(s)? //TODO: Chippie: What is up with the similarly-named variable in the header file? hurstcSchedLngth_; in sched_region.h, but it's passed as a parameter here. Based on the context, I'm assuming ACO's schedule length and cost should instead be added as arguments to this function?
-  InstCount ACOScheduleCost;
-  bool isACOOptimal = false; //TODO: CHIPPIE: Where should this go? Should it become an additional parameter? Why is isLstOptml a reference parameter? Or don't add it as a parameter -- just rename the existing one to "isInitialScheduleOptimal" or something? Or should they all be 3 reference parameters???
-  InstSchedule *initialSchedule = NULL;
-  bool initialScheduleOptimal = false;
-  llvm::opt_sched::InstCount initialScheduleLength; //TODO: CHIPPIE: Initialization value(s)?
-  InstCount initialScheduleCost;
+  InstCount initialScheduleLength;
+  InstCount initialScheduleCost = 0;
   FUNC_RESULT rslt = RES_SUCCESS;
   Milliseconds hurstcTime = 0;
   Milliseconds boundTime = 0;
@@ -100,8 +95,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   Milliseconds vrfyTime = 0;
   Milliseconds acoTime = 0;
   Milliseconds acoStart = 0;
-  Milliseconds boundStart;
-
+  
   enumCrntSched_ = NULL;
   enumBestSched_ = NULL;
   bestSched = bestSched_ = NULL;
@@ -122,6 +116,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
     * 1) Heuristic
     * 2) ACO
     * 3) Branch & Bound
+    * 4) ACO (TODO)
     * 
     * Each of these 3 algorithms can be individually disabled, but one of the heuristic or ACO must be enabled. (TODO: CHIPPIE)
     */
@@ -164,6 +159,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   CmputAbslutUprBound_();
   schedLwrBound_ = dataDepGraph_->GetSchedLwrBound();
 
+  // Step #1: Find the heuristic schedule if enabled.
   if (heuristicSchedulerEnabled) {
     cout << "TODO: Heuristic Scheduler is enabled.\n"; //TODO: Remove this debugging line when done.
     Milliseconds hurstcStart = Utilities::GetProcessorTime();
@@ -172,12 +168,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
       Logger::Fatal("Out of memory.");
 
     lstSchdulr = AllocHeuristicScheduler_();
-
-    // Step #1: Find the heuristic schedule.
+    
     rslt = lstSchdulr->FindSchedule(lstSched, this);
-    cout << "[CHIPPIE: DEBUG] Right after getting sched length, doing lstSched->GetCost(): return value was " << lstSched->GetCost() << "\n";
-    cout << "[CHIPPIE: DEBUG] Right after getting sched length, doing lstSched->GetCrntLngth(): return value was " << lstSched->GetCrntLngth() << "\n";
-
+   
     if (rslt != RES_SUCCESS) {
       Logger::Info("List scheduling failed");
       delete lstSchdulr;
@@ -185,142 +178,64 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
       return rslt;
     }
 
-    //TODO: CHIPPIE: Need to do this both for ACO and the HEURISTIC scheduler? Think so, yes...
     hurstcTime = Utilities::GetProcessorTime() - hurstcStart;
     stats::heuristicTime.Record(hurstcTime);
     if (hurstcTime > 0)
       Logger::Info("Heuristic_Time %d", hurstcTime);
-
-#ifdef IS_DEBUG_SLIL_PRINTOUT //TODO: CHIPPIE: Does ACO need this?
-    if (OPTSCHED_gPrintSpills) {
-      const auto &slilVector = this->GetSLIL_();
-      for (int j = 0; j < slilVector.size(); j++) {
-        Logger::Info(
-            "SLIL after Heuristic Scheduler for dag %s Type %d %s is %d.",
-            dataDepGraph_->GetDagID(), j, machMdl_->GetRegTypeName(j).c_str(),
-            slilVector[j]);
-      }
-    }
-#endif
-
-    boundStart = Utilities::GetProcessorTime();
-    hurstcSchedLngth_ = lstSched->GetCrntLngth();
-
-    //The heuristic is the first schedule to run, so guaranteed to provide the initial values for these variables.
-    initialSchedule = lstSched;
-    bestSchedLngth_ = initialScheduleLength_ = initialScheduleLength = hurstcSchedLngth_;
-    assert(bestSchedLngth_ >= schedLwrBound_);
-    bestSched = bestSched_ = lstSched;
-
-    // Step #2: Compute the lower bounds and cost upper bound.
-    if (rgnTimeout == 0) //TODO: CHIPPIE: NOTE: This was a hack to disable B&B before these scheduler enabling flags tasks. Should it now be removed?
-      costLwrBound_ = CmputCostLwrBound();
-    else
-      CmputLwrBounds_(false); //TODO: CHIPPIE: I highly suspect that this needs to run before the upper bound & is_optimal checks...YUP. Check line 760 of this file.
-    assert(schedLwrBound_ <= initialSchedule->GetCrntLngth());
-
+    
+    hurstcSchedLngth_ = lstSched->GetCrntLngth(); 
     InstCount hurstcExecCost;
-    Config &schedIni = SchedulerOptions::getInstance();
+    // Compute cost for Heuristic list scheduler, this must be called before
+    // calling GetCost() on the InstSchedule instance.
     CmputNormCost_(lstSched, CCM_DYNMC, hurstcExecCost, true);
-    initialScheduleCost_ = initialScheduleCost = hurstcCost_ = lstSched->GetCost();
-    cout << "[CHIPPIE: DEBUG] Right after lstSched->GetCost(): return value was " << lstSched->GetCost() << "\n";
-    isLstOptml = CmputUprBounds_(lstSched, false, hurstcCost_, hurstcSchedLngth_);
-
-    boundTime = Utilities::GetProcessorTime() - boundStart;
-    stats::boundComputationTime.Record(boundTime); //TODO: CHIPPIE: Does ACO need this too? If so, what should the new statistic's name be? Etc.
-
-    FinishHurstc_(); //TODO: CHIPPIE: Need one for ACO?
+    hurstcCost_ = lstSched->GetCost();
+    cout << "[CHIPPIE: DEBUG] Right after lstSched->GetCost(): return value was " << hurstcCost_ << "\n";
+   
+    // This schedule is optimal so ACO will not be run
+    // so set bestSched here.
+    if (hurstcCost_ == 0) {
+      cout << "[CHIPPIE: DEBUG] ***** HEURISTIC SCHEDULE IS OPTIMAL *****\n"; //TODO: CHIPPIE: REMOVE DEBUGGING STATEMENT.
+      isLstOptml = true;
+      bestSched = bestSched_ = lstSched;
+      bestSchedLngth_ = hurstcSchedLngth_;
+      bestCost_ = hurstcCost_;
+    }
+   
+    FinishHurstc_(); //TODO: CHIPPIE: Need one for ACO. Will need to also add some new statistic for the ACO counterparts.
 
     //  #ifdef IS_DEBUG_SOLN_DETAILS_1
     Logger::Info(
         "The list schedule is of length %d and spill cost %d. Tot cost = %d",
-        bestSchedLngth_, lstSched->GetSpillCost(), bestCost_);
+        hurstcSchedLngth_, lstSched->GetSpillCost(), hurstcCost_);
     //  #endif
 
-  #ifdef IS_DEBUG_PRINT_SCHEDS
+#ifdef IS_DEBUG_PRINT_SCHEDS
     lstSched->Print(Logger::GetLogStream(), "Heuristic");
-  #endif
-  #ifdef IS_DEBUG_PRINT_BOUNDS
+#endif
+#ifdef IS_DEBUG_PRINT_BOUNDS
     dataDepGraph_->PrintLwrBounds(DIR_FRWRD, Logger::GetLogStream(),
                                   "CP Lower Bounds");
-  #endif
-
-    if (rgnTimeout == 0) //TODO: CHIPPIE: NOTE: This was a hack to disable B&B before these scheduler enabling flags task.
-      isLstOptml = true;
-
-    if (isLstOptml)
-    {
-      initialScheduleOptimal = true;
-      cout << "[CHIPPIE: DEBUG] ***** HEURISTIC SCHEDULE IS OPTIMAL *****\n"; //TODO: CHIPPIE: REMOVE DEBUGGING STATEMENT.
-    }
-
-    //TODO: CHIPPIE: Does ACO need something like this? Don't think so...Then, does this need to be modified?
-    // (Chris): If the cost function is SLIL, then the list schedule is considered
-    // optimal if PERP is 0.
-    if (filterByPerp && !isLstOptml && spillCostFunc_ == SCF_SLIL) {
-      const InstCount *regPressures = nullptr;
-      auto regTypeCount = lstSched->GetPeakRegPressures(regPressures);
-      InstCount sumPerp = 0;
-      for (int i = 0; i < regTypeCount; ++i) {
-        int perp = regPressures[i] - machMdl_->GetPhysRegCnt(i);
-        if (perp > 0)
-          sumPerp += perp;
-      }
-      if (sumPerp == 0) {
-        isLstOptml = true;
-        Logger::Info("Marking SLIL list schedule as optimal due to zero PERP.");
-      }
-    }
-
-  #if defined(IS_DEBUG_SLIL_OPTIMALITY) //TODO: CHIPPIE: Does ACO need this?
-    // (Chris): This code prints a statement when a schedule is SLIL-optimal but
-    // not PERP-optimal.
-    if (spillCostFunc_ == SCF_SLIL && bestCost_ == 0) {
-      const InstCount *regPressures = nullptr;
-      auto regTypeCount = lstSched->GetPeakRegPressures(regPressures);
-      InstCount sumPerp = 0;
-      for (int i = 0; i < regTypeCount; ++i) {
-        int perp = regPressures[i] - machMdl_->GetPhysRegCnt(i);
-        if (perp > 0)
-          sumPerp += perp;
-      }
-      if (sumPerp > 0) {
-        Logger::Info("Dag %s is SLIL optimal but not PERP optimal (PERP=%d).",
-                    dataDepGraph_->GetDagID(), sumPerp);
-      }
-    }
-  #endif
-    if (EnableEnum_() == false) { //TODO: CHIPPIE: Does ACO need this?
-      delete lstSchdulr;
-      return RES_FAIL;
-    }
+#endif
   }
 
-  // Step #3: Try to find the optimal schedule with ACO if the heuristic was not optimal.
-
-  if (acoSchedulerEnabled && false == initialScheduleOptimal) { //If the Heuristic algorithm already produced the optimal result, don't run ACO or B&B.
+  // Step #2: Use ACO to find a schedule if enabled.
+  if (acoSchedulerEnabled && false == isLstOptml) { //If the Heuristic algorithm already produced the optimal result, don't run ACO or B&B.
     //TODO: CHIPPIE: If ACO's schedule is optimal, set the best schedule to that (and don't run B&B).
     //TODO: CHIPPIE: If neither ACO's or the Heuristic's schedule is optimal, compare ACO's result with the heuristic's and then set the initial_schedule to that.
 
     cout << "TODO: ACO Scheduler is enabled & running.\n"; //TODO: Remove this debugging line when done.
     acoStart = Utilities::GetProcessorTime();
     acoSchedule = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-    if (acoSchedule == NULL) {
-      Logger::Fatal("Out of memory.");
-    }
+    if (acoSchedule == NULL)
+      Logger::Fatal("Out of memory."); 
 
-    acoSchdulr = new ACOScheduler(dataDepGraph_, machMdl_, abslutSchedUprBound_, hurstcPrirts_, initialSchedule, vrfySched_);
-
-    rslt = acoSchdulr->FindSchedule(acoSchedule, this);
-
+    rslt = runACO(acoSchedule, lstSched);
     if (rslt != RES_SUCCESS) {
       Logger::Info("ACO scheduling failed");
-      if (lstSchdulr) {
+      if (lstSchdulr) 
         delete lstSchdulr;
-      }
-      if (lstSched) {
+      if (lstSched) 
         delete lstSched;
-      }
       delete acoSchdulr;
       delete acoSchedule;
       return rslt;
@@ -328,100 +243,144 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
 
     acoTime = Utilities::GetProcessorTime() - acoStart;
     stats::acoTime.Record(acoTime);
-    if (acoTime > 0) {
+    if (acoTime > 0)
       Logger::Info("ACO_Time %d", acoTime);
-    }
 
-    boundStart = Utilities::GetProcessorTime(); //TODO: CHIPPIE: Need this?
-    acoScheduleLength_ = ACOScheduleLength = acoSchedule->GetCrntLngth();
-    acoScheduleCost_ = ACOScheduleCost = acoSchedule->GetCost();
-    cout << "[CHIPPIE: DEBUG] Just finished ACO! Here's the ACO schedule cost: " << acoSchedule->GetCost() << ", and length: " << acoSchedule->GetCrntLngth() << "\n";
-
-    if (rgnTimeout == 0) //TODO: CHIPPIE: NOTE: This was a hack to disable B&B before these scheduler enabling flags task. Remove it now?
-      isACOOptimal = true; //TODO: CHIPPIE: Maybe check first if heuristic was taken or not...don't want to just blindly set this to true if it shouldn't be. //TODO: CHIPPIE: Wait...this whole block of code will only run if the heuristic schedule is not optimal.
-
-    //If the Heuristic schedule did not compute the lower bound, need to do it now. //TODO: CHIPPIE: Can it be computed prior to running either the heuristic or ACO scheduler, somewhere up at the top of the function?
-    if (false == heuristicSchedulerEnabled)
-    {
-      //Run initial lower-bound computation.
-      if (rgnTimeout == 0) //TODO: CHIPPIE: NOTE: This was a hack to disable B&B before these scheduler enabling flags task. Remove it now?
-        costLwrBound_ = CmputCostLwrBound();
-      else
-        CmputLwrBounds_(false);
-      
-      bestSched = initialSchedule = acoSchedule;
-      bestSchedLngth = initialScheduleLength_ = initialScheduleLength = acoScheduleLength_; //TODO: CHIPPIE: Why not bestSchedLngth_ = ... all of that, too?
-      bestCost_ = initialScheduleCost_ = initialScheduleCost = acoScheduleCost_;
-
-      assert(schedLwrBound_ <= initialSchedule->GetCrntLngth());
-    }
-
+    acoScheduleLength_ = acoSchedule->GetCrntLngth();
     InstCount ACOExecCost;
-    Config &schedIni = SchedulerOptions::getInstance();
-    if (!schedIni.GetBool("USE_ACO", false)) { //TODO: CHIPPIE: What does this flag do? Doesn't seem to actually disable ACO...
-      CmputNormCost_(acoSchedule, CCM_DYNMC, ACOExecCost, true);
-    } else {
-      CmputNormCost_(acoSchedule, CCM_STTC, ACOExecCost, false);
-    }
-    isACOOptimal = CmputUprBounds_(acoSchedule, false, acoScheduleCost_, acoScheduleLength_); //TODO: CHIPPIE: If the heuristic already ran and neither the heuristic nor ACO produces an optimal schedule, make sure that B&B gets the correct upper bounds. Is it just the lower of ACO's upper bound and the herustic's upper bound?
-    boundTime = Utilities::GetProcessorTime() - boundStart;
-    stats::boundComputationTime.Record(boundTime); //TODO: CHIPPIE: Need this? And beware that this is currently overwriting what the heuristic block of code set it to.
+    // Compute cost for ACO scheduler, this must be called before
+    // calling GetCost() on the InstSchedule instance.
+    CmputNormCost_(acoSchedule, CCM_STTC, ACOExecCost, false);
+    acoScheduleCost_ = acoSchedule->GetCost();
+    cout << "[CHIPPIE: DEBUG] Just finished ACO! Here's the ACO schedule cost: " << acoScheduleCost_ << ", and length: " << acoScheduleLength_ << "\n";
 
-    if (isACOOptimal) {
+    // If ACO is run then that means either:
+    // 1.) Heuristic was not run
+    // 2.) Heuristic was not optimal
+    // In both cases, the current best will be ACO if
+    // ACO is optimal so set bestSched here.
+    if (acoScheduleCost_ == 0) {
       cout << "[CHIPPIE: DEBUG] ***** ACO SCHEDULE IS OPTIMAL *****\n"; //TODO: CHIPPIE: REMOVE DEBUGGING STATEMENT.
+      isLstOptml  = true;
+      bestSched = bestSched_ = acoSchedule;
+      bestSchedLngth_ = acoScheduleLength_;
+      bestCost_ = acoScheduleCost_;
     }
-
-    //There are 3 possible situations:
-    // A) Heuristic was never run. In that case, just use ACO and run with its results, into B&B.
-    // B) Heuristic was not optimal, but ACO is. In that case, just use ACO's result for the initial schedule AND the best schedule. And don't run B&B, exit the function (since B&B only runs if the optimal schedule was not found).
-    // C) Neither scheduler was optimal. In that case, compare the two schedules and use the one that's better as the input (initialSched) for B&B.
-    cout << "[CHIPPIE: DEBUG] ***** lower bound = " << schedLwrBound_ << ", ACO len =" << ACOScheduleLength << ", ACO cost = " << ACOScheduleCost << " *****\n"; //TODO: CHIPPIE: REMOVE DEBUGGING STATEMENT.
-    if (false == heuristicSchedulerEnabled || isACOOptimal || ACOScheduleCost < hurstcCost_) { //If the heuristic was not run (and thus no initial schedule was set), or if the heuristic schedule is not optimal but ACO's is, or if neither schedule is optimal but ACO's is better, then set the initial and best schedule to ACO's.
-      //TODO: CHIPPIE: Determine what needs to be done between both? And determine what needs to be done in the case of heuristic schedule already having run?
-      bestSched = bestSched_ = initialSchedule = acoSchedule;
-      bestSchedLngth_ = initialScheduleLength_ = initialScheduleLength = ACOScheduleLength;
-      bestCost_ = initialScheduleCost_ = initialScheduleCost = ACOScheduleCost;
-      cout << "[CHIPPIE: DEBUG] ***** best length = " << bestSchedLngth_ << ", lower bound = " << schedLwrBound_ << ", ACO len =" << ACOScheduleLength << " *****\n"; //TODO: CHIPPIE: REMOVE DEBUGGING STATEMENT.
-      assert(bestSchedLngth_ >= schedLwrBound_);
-
-      initialScheduleOptimal = isACOOptimal;
-
-      //TODO: CHIPPIE: Done with this portion?
+  }
+  
+  // If an optimal schedule was found then it should have already
+  // been taken care of when optimality was discovered.
+  // Thus we only account for cases where no optimal schedule
+  // was found.
+  if (!isLstOptml ) {
+//There are 3 possible situations:
+    // A) ACO was never run. In that case, just use Heuristic and run with its results, into B&B.
+    if (!acoSchedulerEnabled) {
+      bestSched = bestSched_ = lstSched;
+      bestSchedLngth_ = hurstcSchedLngth_;
+      bestCost_ = hurstcCost_;
+    }
+    // B) Heuristic was never run. In that case, just use ACO and run with its results, into B&B.
+    else if (!heuristicSchedulerEnabled) {
+      bestSched = bestSched_ = acoSchedule;
+      bestSchedLngth_ = acoScheduleLength_;
+      bestCost_ = acoScheduleCost_;
+    // C) Neither scheduler was optimal. In that case, compare the two schedules and use the one that's better as the input (initialSched) for B&B.      
     } else {
-      //TODO: CHIPPIE: Does anything else need to happen here? Nominally, the upper bound would need to be reset if ACO was not the lower one, but the compute upper bound code should already handle that sufficiently.
+      compareSchedules(lstSched, acoSchedule, bestSched_);
+      bestSched = bestSched_;
+      bestSchedLngth_ = bestSched_->GetCrntLngth();
+      bestCost_ = bestSched_->GetCost();
     }
+  }
+  // Step #2: Compute the lower bounds and cost upper bound.
+  Milliseconds boundStart = Utilities::GetProcessorTime();
+  assert(bestSchedLngth_ >= schedLwrBound_);
+  if (rgnTimeout == 0)
+    costLwrBound_ = CmputCostLwrBound();
+  else
+    CmputLwrBounds_(false);
+  assert(schedLwrBound_ <= bestSched_->GetCrntLngth());
 
-     Logger::Info(
-         "The ACO schedule is of length %d and spill cost %d. Tot cost = %d",
-         acoScheduleLength_, acoSchedule->GetSpillCost(), bestCost_);
+  // Only used to calculate upper bounds
+  // Was previously used to check for optimality.
+  CmputUprBounds_(lstSched, false);
+  boundTime = Utilities::GetProcessorTime() - boundStart;
+  stats::boundComputationTime.Record(boundTime);
 
-    //TODO: CHIPPIE: There's some other stuff that the old combined heuristic-aco scheduler code has...what of that needs to be copied, and how does it need to be modified?
-    //For example, the debug logs that were here originally, plus the #ifdef'd code chunks.
-  } else {
-    if (acoSchedulerEnabled) {
-      cout << "TODO: ACO Scheduler not run, but enabled (heuristic is optimal!).\n"; //TODO: CHIPPIE: Remove this when done debugging.
+#ifdef IS_DEBUG_PRINT_SCHEDS
+  lstSched->Print(Logger::GetLogStream(), "Heuristic");
+#endif
+#ifdef IS_DEBUG_PRINT_BOUNDS
+  dataDepGraph_->PrintLwrBounds(DIR_FRWRD, Logger::GetLogStream(),
+                                "CP Lower Bounds");
+#endif
+
+  if (rgnTimeout == 0)
+    isLstOptml = true; //TODO: CHIPPIE: NOTE: This was a hack to disable B&B before these scheduler enabling flags tasks.
+
+  // (Chris): If the cost function is SLIL, then the list schedule is considered
+  // optimal if PERP is 0.
+  if (filterByPerp && !isLstOptml && spillCostFunc_ == SCF_SLIL) {
+    const InstCount *regPressures = nullptr;
+    auto regTypeCount = lstSched->GetPeakRegPressures(regPressures);
+    InstCount sumPerp = 0;
+    for (int i = 0; i < regTypeCount; ++i) {
+      int perp = regPressures[i] - machMdl_->GetPhysRegCnt(i);
+      if (perp > 0)
+        sumPerp += perp;
+    }
+    if (sumPerp == 0) {
+      isLstOptml = true;
+      Logger::Info("Marking SLIL list schedule as optimal due to zero PERP.");
     }
   }
 
-  // Step #4: Find the optimal schedule if the heuristc or ACO were not optimal.
-  Milliseconds enumStart = Utilities::GetProcessorTime();
-
+#if defined(IS_DEBUG_SLIL_OPTIMALITY)
+  // (Chris): This code prints a statement when a schedule is SLIL-optimal but
+  // not PERP-optimal.
+  if (spillCostFunc_ == SCF_SLIL && bestCost_ == 0) {
+    const InstCount *regPressures = nullptr;
+    auto regTypeCount = lstSched->GetPeakRegPressures(regPressures);
+    InstCount sumPerp = 0;
+    for (int i = 0; i < regTypeCount; ++i) {
+      int perp = regPressures[i] - machMdl_->GetPhysRegCnt(i);
+      if (perp > 0)
+        sumPerp += perp;
+    }
+    if (sumPerp > 0) {
+      Logger::Info("Dag %s is SLIL optimal but not PERP optimal (PERP=%d).",
+                   dataDepGraph_->GetDagID(), sumPerp);
+    }
+  }
+#endif
+  if (EnableEnum_() == false) {
+    delete lstSchdulr;
+    return RES_FAIL;
+  }
+ 
 #ifdef IS_DEBUG_BOUNDS
   Logger::Info("Sched LB = %d, Sched UB = %d", schedLwrBound_, schedUprBound_);
 #endif
-
+ 
+  initialSchedule = bestSched_;
+  initialScheduleCost = bestCost_;
+  initialScheduleLength = bestSchedLngth_;
+  
+// Step #4: Find the optimal schedule if the heuristc was not optimal.
   if (bbSchedulerEnabled) {
-    //Make sure the bounds information are all correct with the chosen initial schedule.
-
+    Milliseconds enumStart = Utilities::GetProcessorTime();
     cout << "TODO: BB scheduler is enabled.\n";
-    //initialScheduleOptimal = false; //TODO: CHIPPIE: Remove this when done debugging. //Yes, this flow looks to work correctly.
-    if (false == initialScheduleOptimal) {
+    //isLstOptml = false; //TODO: CHIPPIE: Remove this when done debugging. //Yes, this flow works correctly.
+    if (false == isLstOptml) { 
       cout << "TODO: Running BB scheduler...\n"; //TODO: CHIPPIE: Remove this when done debugging.
       dataDepGraph_->SetHard(true);
       rslt = Optimize_(enumStart, rgnTimeout, lngthTimeout);
       Milliseconds enumTime = Utilities::GetProcessorTime() - enumStart;
-
-      if (hurstcTime > 0) { //TODO: CHIPPIE: This shouldn't use the heuristic time anymore, right? What should this now use? initialScheduleTime?
+      
+      // TODO: Implement one for ACO also. Maybe also Heuristic + ACO? 
+      // Priority: Low
+      if (hurstcTime > 0) { //TODO: CHIPPIE: This shouldn't use the heuristic time...what should this now use? initialScheduleTime?
         enumTime /= hurstcTime;
         stats::enumerationToHeuristicTimeRatio.Record(enumTime);
       }
@@ -443,40 +402,36 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
     }
 
     if (rgnTimeout != 0) {
-      bool optimalSchedule = initialScheduleOptimal || (rslt == RES_SUCCESS);
+      bool optimalSchedule = isLstOptml || (rslt == RES_SUCCESS);
        Logger::Info("Best schedule for DAG %s has cost %d and length %d. The "
                    "schedule is %s",
                    dataDepGraph_->GetDagID(), bestCost_, bestSchedLngth_,
                    optimalSchedule ? "optimal" : "not optimal");
     }
-  }
-
-  //TODO: CHIPPIE: Everything hereafter, should it run for _all_ of the schedulers? Regardless of which ones are enabled?
-  //I.e. are the following blocks of code BB specific? (Doesn't look it...)
 
 #ifdef IS_DEBUG_PRINT_PERP_AT_EACH_STEP
-  Logger::Info("Printing PERP at each step in the schedule.");
+    Logger::Info("Printing PERP at each step in the schedule.");
 
-  int costSum = 0;
-  for (int i = 0; i < dataDepGraph_->GetInstCnt(); ++i) {
-    Logger::Info("Cycle: %lu Cost: %lu", i, bestSched_->GetSpillCost(i));
-    costSum += bestSched_->GetSpillCost(i);
-  }
-  Logger::Info("Cost Sum: %lu", costSum);
+    int costSum = 0;
+    for (int i = 0; i < dataDepGraph_->GetInstCnt(); ++i) {
+      Logger::Info("Cycle: %lu Cost: %lu", i, bestSched_->GetSpillCost(i));
+      costSum += bestSched_->GetSpillCost(i);
+    }
+    Logger::Info("Cost Sum: %lu", costSum);
 #endif
 
-  if (SchedulerOptions::getInstance().GetString(
-          "SIMULATE_REGISTER_ALLOCATION") != "NO") {
-    //#ifdef IS_DEBUG
-    RegAlloc_(bestSched, lstSched);
-    //#endif
+    if (SchedulerOptions::getInstance().GetString(
+            "SIMULATE_REGISTER_ALLOCATION") != "NO") {
+      //#ifdef IS_DEBUG
+      RegAlloc_(bestSched, initialSchedule);
+      //#endif
+    }
+
+    enumTime = Utilities::GetProcessorTime() - enumStart;
+    stats::enumerationTime.Record(enumTime);
   }
-
-  enumTime = Utilities::GetProcessorTime() - enumStart;
-  stats::enumerationTime.Record(enumTime);
-
+  
   Milliseconds vrfyStart = Utilities::GetProcessorTime();
-
   if (vrfySched_) {
     bool isValidSchdul = bestSched->Verify(machMdl_, dataDepGraph_);
 
@@ -495,7 +450,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
 
   dataDepGraph_->SetFinalBounds(finalLwrBound, finalUprBound);
 
-  FinishOptml_(); //TODO: CHIPPIE: And what about this? No changes?
+  FinishOptml_();
 
   bool tookBest = ChkSchedule_(bestSched, initialSchedule);
   if (tookBest == false) {
@@ -509,9 +464,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   if (NULL != lstSched && bestSched != lstSched) {
       delete lstSched;
   }
-  if (acoSchdulr) {
-    delete acoSchdulr;
-  }
   if (NULL != acoSchedule && bestSched != acoSchedule) {
     delete acoSchedule;
   }
@@ -524,21 +476,25 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   bestSchedLngth = bestSchedLngth_;
   hurstcCost = hurstcCost_;
   hurstcSchedLngth = hurstcSchedLngth_;
+  
   // (Chris): Experimental. Discard the schedule based on sched.ini setting.
   if (spillCostFunc_ == SCF_SLIL) {
-    bool optimal = initialScheduleOptimal || (rslt == RES_SUCCESS);
+    bool optimal = isLstOptml || (rslt == RES_SUCCESS);
     if ((blocksToKeep == BLOCKS_TO_KEEP::ZERO_COST && bestCost != 0) ||
         (blocksToKeep == BLOCKS_TO_KEEP::OPTIMAL && !optimal) ||
         (blocksToKeep == BLOCKS_TO_KEEP::IMPROVED &&
-         !(bestCost < initialScheduleCost)) ||									//TODO: CHIPPIE: NEER! Why was it checking heuristic specifically?
+         !(bestCost < initialScheduleCost)) ||									
         (blocksToKeep == BLOCKS_TO_KEEP::IMPROVED_OR_OPTIMAL &&
-         !(optimal || bestCost < initialScheduleCost))) {						//TODO: CHIPPIE: NEER! Why was it checking heuristic specifically?
+         !(optimal || bestCost < initialScheduleCost))) {
       delete bestSched;
       bestSched = nullptr;
       return rslt;
     }
   }
-#if defined(IS_DEBUG_COMPARE_SLIL_BB) //TODO: CHIPPIE: This block will likely need to be updated...I note that there are some references to isLstOptml, which will need to be updated if the heuristic scheduler is disabled, and also may need to be changed to account for ACO. When and how should it reference the initial schedule instead?
+  
+  // TODO: Update this
+  // Priority: Low
+#if defined(IS_DEBUG_COMPARE_SLIL_BB) //TODO: CHIPPIE: This block will likewise need to be updated...I note that there are some references to isLstOptml, which will need to be updated if the heuristic scheduler is disabled, and also may need to be changed to account for ACO.
   {
     const auto &status = [&]() {
       switch (rslt) {
@@ -605,8 +561,8 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule( //TODO: CHIPPIE: Add helper functi
   Logger::Info("Final spill cost is %d for DAG %s.", bestSched_->GetSpillCost(),
                dataDepGraph_->GetDagID());
 #endif
-#if defined(IS_DEBUG_PRINT_PEAK_FOR_ENUMERATED) //TODO: CHIPPIE: Update this block too?
-  if (!isLstOptml) { //TODO: CHIPPIE: What to do about this? initialScheduleOptimal?
+#if defined(IS_DEBUG_PRINT_PEAK_FOR_ENUMERATED)
+  if (!isLstOptml) {
     InstCount maxSpillCost = 0;
     for (int i = 0; i < dataDepGraph_->GetInstCnt(); ++i) {
       if (bestSched->GetSpillCost(i) > maxSpillCost)
@@ -712,24 +668,15 @@ void SchedRegion::CmputLwrBounds_(bool useFileBounds) {
 }
 
 //TODO: CHIPPIE: This function needs to not use hurstcCost_? Because what if ACO is happening right now...?
-bool SchedRegion::CmputUprBounds_(InstSchedule *schedule, bool useFileBounds, InstCount& scheduleCost, InstCount scheduleLength) {
+bool SchedRegion::CmputUprBounds_(InstSchedule *schedule, bool useFileBounds) {
   if (useFileBounds) { //TODO: CHIPPIE: Why?
-    scheduleCost = dataDepGraph_->GetFileCostUprBound();
-    scheduleCost -= GetCostLwrBound();
+    hurstcCost_ = dataDepGraph_->GetFileCostUprBound();
+    hurstcCost_ -= GetCostLwrBound();
   }
-
-  //TODO: CHIPPIE: Why the below lines? Why not done in the calling function?
-	bestCost_ = scheduleCost;
-	bestSchedLngth_ = scheduleLength;
 
   if (bestCost_ == 0) {
     // If the heuristic schedule is optimal, we are done!
-    InstCount tentativeUpperBound = schedule->GetCrntLngth();
-    if (tentativeUpperBound < schedUprBound_ || INVALID_VALUE == schedUprBound_) {
-      //Do not update the upper bound unless it's found a better one.
-      schedUprBound_ = tentativeUpperBound;
-      std::cout << "[CHIPPIE: DEBUG CmputUprBounds()] Found a better upper bound: " << schedUprBound_ << "\n"; //TODO: CHIPPIE: Remove this when done debugging.
-    }
+    schedUprBound_ = bestSchedLngth_;
     return true;
   } else if (isSecondPass) {
     // In the second pass, the upper bound is the length of the min-RP schedule
@@ -831,3 +778,47 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
 }
 
 void SchedRegion::InitSecondPass() { isSecondPass = true; }
+
+FUNC_RESULT SchedRegion::runACO(InstSchedule *returnSched, InstSchedule *initSched) {
+  InitForSchdulng();
+  ACOScheduler *acoSchdulr = new ACOScheduler(dataDepGraph_, machMdl_, abslutSchedUprBound_, hurstcPrirts_, vrfySched_);
+  acoSchdulr->setInitialSched(initSched);
+  FUNC_RESULT rslt = acoSchdulr->FindSchedule(returnSched, this);
+  delete acoSchdulr;
+  return rslt;
+}
+
+void SchedRegion::compareSchedules(InstSchedule *first, InstSchedule *second, InstSchedule *&third) {
+  InstCount firstCost = first->GetCost();
+  InstCount secondCost = second->GetCost();
+  
+  // Instances where costs are equal, take sched. length into account
+  if (firstCost == secondCost) {
+    InstCount firstLength = first->GetCrntLngth();
+    InstCount secondLength = second->GetCrntLngth();
+    // Instances where both costs and length are equal,
+    // just take first
+    if (firstLength == secondLength) {
+      third = first;
+    }
+    else if (firstLength < secondLength) {
+      Logger::Info("The first schedule was better than the second!");
+      third = first;
+    }
+    else if (firstLength > secondLength) {
+      Logger::Info("The second schedule was better than the second!");
+      third = second;
+    }
+  }
+  // First has better cost than second
+  else if (firstCost < secondCost) {
+    Logger::Info("The first schedule was better than the second!");
+    third = first;
+  }
+  // Second has better cost than First
+  else if (firstCost > secondCost) {
+    Logger::Info("The second schedule was better than the second!");
+    third = second;
+  }
+ }
+

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -82,7 +82,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     InstCount &hurstcSchedLngth, InstSchedule *&bestSched, bool filterByPerp,
     const BLOCKS_TO_KEEP blocksToKeep) {
   ConstrainedScheduler *lstSchdulr = NULL;
-  InstSchedule *initialSchedule = nullptr;
+  InstSchedule *InitialSchedule = nullptr;
   InstSchedule *lstSched = NULL;
   InstSchedule *AcoSchedule = nullptr;
   InstCount InitialScheduleLength = 0;
@@ -356,7 +356,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   Logger::Info("Sched LB = %d, Sched UB = %d", schedLwrBound_, schedUprBound_);
 #endif
 
-  initialSchedule = bestSched_;
+  InitialSchedule = bestSched_;
   InitialScheduleCost = bestCost_;
   InitialScheduleLength = bestSchedLngth_;
 
@@ -412,7 +412,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     if (SchedulerOptions::getInstance().GetString(
             "SIMULATE_REGISTER_ALLOCATION") != "NO") {
       //#ifdef IS_DEBUG
-      RegAlloc_(bestSched, initialSchedule);
+      RegAlloc_(bestSched, InitialSchedule);
       //#endif
     }
 
@@ -472,7 +472,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
   FinishOptml_();
 
-  bool tookBest = ChkSchedule_(bestSched, initialSchedule);
+  bool tookBest = ChkSchedule_(bestSched, InitialSchedule);
   if (tookBest == false) {
     bestCost_ = InitialScheduleCost;
     bestSchedLngth_ = InitialScheduleLength;

--- a/lib/Scheduler/stats.cpp
+++ b/lib/Scheduler/stats.cpp
@@ -164,7 +164,7 @@ IntDistributionStat traceOptimalScheduleLength("Trace optimal schedule length");
 
 IntDistributionStat regionBuildTime("Region build time");
 IntDistributionStat heuristicTime("Heuristic time");
-IntDistributionStat acoTime("ACO time");
+IntDistributionStat AcoTime("ACO time");
 IntDistributionStat boundComputationTime("Bound computation time");
 IntDistributionStat enumerationTime("Enumeration time");
 IntDistributionStat


### PR DESCRIPTION
Change notes:
- Moved bounds calculation. Lower bound is calculated before scheduling because the cost calculation is dependent on the lower bound estimate. Upper bound is calculated after heuristic and ACO.
- Pass optional initial schedule to ACO with helper function instead of requiring it in the constructor.
- Removed some redundant code and changed new code to match LLVM style.
- List scheduler in the second pass will always be enabled because it is required to create a valid schedule with latency accounted for.

Regression tests verified:
One-Pass Scheduler:
- LUC_NID Heuristic scheduler only, B&B enumerator disabled - No regression
- LUC_NID Heuristic scheduler and B&B enumerator enabled - No regression
- ACO only, B&B Enum. disabled - No regression

Two-Pass Scheduler:
- LUC_NID Heuristic scheduler, B&B enumerator enabled - No regression

Additional Note: Scripts may need to be updated.